### PR TITLE
Update test_client.py

### DIFF
--- a/cloud/test_client.py
+++ b/cloud/test_client.py
@@ -29,7 +29,7 @@ def send_dummy_data_with_retry(data, max_retries=3):
                 print(response.json())
                 return response.json()
 
-            eli 400 <= response.status_code < 500:
+            elif 400 <= response.status_code < 500:
                 print(f"❌ Client Error {response.status_code}:")
                 print(response.text)
                 return None  # Kein Retry bei Client-Fehlern

--- a/cloud/test_client.py
+++ b/cloud/test_client.py
@@ -1,7 +1,8 @@
 import requests
 import json
+import time
 
-# URL von deinem lokalen FastAPI-Server
+# URL deines lokalen FastAPI-Servers
 url = "http://127.0.0.1:8000/batterypass/"
 
 # Dummy-Daten zum Testen
@@ -16,20 +17,36 @@ headers = {
     "Content-Type": "application/json"
 }
 
-# Funktion zum Senden der Dummy-Daten
-def send_dummy_data():
-    try:
-        response = requests.put(url, headers=headers, data=json.dumps(dummy_data))
-        
-        if response.status_code == 200:
-            print("✅ Success:")
-            print(response.json())
-        else:
-            print(f"❌ Error {response.status_code}:")
-            print(response.text)
-    except Exception as e:
-        print("❌ Exception occurred:", str(e))
+# Neue Funktion mit Retry-Mechanismus
+def send_dummy_data_with_retry(data, max_retries=3):
+    attempt = 0
+    while attempt < max_retries:
+        try:
+            response = requests.put(url, headers=headers, data=json.dumps(data))
+            
+            if response.status_code == 200:
+                print("✅ Success:")
+                print(response.json())
+                return response.json()
+
+            eli 400 <= response.status_code < 500:
+                print(f"❌ Client Error {response.status_code}:")
+                print(response.text)
+                return None  # Kein Retry bei Client-Fehlern
+
+            else:
+                print(f"⚠️ Server Error {response.status_code}, retrying...")
+
+        except requests.exceptions.RequestException as e:
+            print(f"❌ Network Exception: {str(e)}")
+
+        attempt += 1
+        print(f"🔁 Retry {attempt}/{max_retries} in 2s...\n")
+        time.sleep(2)
+
+    print("❌ Max retries reached. Giving up.")
+    return None
 
 # Hauptfunktion
 if __name__ == "__main__":
-    send_dummy_data()
+    send_dummy_data_with_retry(dummy_data)


### PR DESCRIPTION
This pull request implements a retry mechanism for data transfer from the client to the cloud.

## Closes
Closes #77

## Relevant Notes
- Retries up to 3 times on network or server-side errors (5xx)
- Waits 2 seconds between each retry attempt
- Skips retry on client errors (4xx), such as 400 or 401
- Added to `cloud/test_client.py` in the function `send_dummy_data_with_retry`

## Attribution
Authored by @ensarozen

---

Please assign this PR to the appropriate reviewers.
